### PR TITLE
test(qc-wallet): Add declining credential E2E test

### DIFF
--- a/aries-mobile-tests/behave.ini
+++ b/aries-mobile-tests/behave.ini
@@ -12,4 +12,4 @@ stdout_capture=false
 print_page_source_on_failure=False
 print_qr_code_on_creation=False
 save_qr_code_on_creation=False
-test_retry_attempts=1
+test_retry_attempts=3

--- a/aries-mobile-tests/features/bc_wallet/onboarding.feature
+++ b/aries-mobile-tests/features/bc_wallet/onboarding.feature
@@ -1,5 +1,5 @@
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/8
-@Onboarding @bc_wallet @Story_8 @normal
+@Onboarding @bc_wallet @qc_wallet @Story_8 @normal
 Feature: Onboarding
   In order to understand how the app works
   As a new holder

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -28,7 +28,7 @@ Feature: Proof
    #| CANdyWebIssuer    | # CANdy - Unverified Person Issuer | Unverified Person | First Name;Last Name;Date of Birth;Street Address;Postal Code;City;Province;Country;Issued | Sheldon;Regular;1989-03-04;123 Perfect Street;A2V 3E1;Awesome City;BC;Canada;2022-03-14T23:27:20.133Z |
 
 
-   @T002-Proof @critical @AcceptanceTest @Story_29 @SmokeTest
+   @T002-Proof @critical @AcceptanceTest @Story_29 @SmokeTest @qc_wallet
    Scenario: Holder accepts the proof request
       Given the User has skipped on-boarding
       And the User has accepted the Terms and Conditions

--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -4,7 +4,7 @@
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/426
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/425
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/422
-@Security @bc_wallet
+@Security @bc_wallet @qc_wallet
 Feature: Secure your Wallet
   In order to be reassured that my digital wallet will not be used maliciously
   As a person who is curious but cautious of digital wallets
@@ -32,7 +32,7 @@ Feature: Secure your Wallet
     #And authenticates with thier biometrics
     And they enter thier PIN as "369369"
     Then they have access to the app
-
+    
 
   @T003-Security @critical @AcceptanceTest @ExceptionTest @Story_426 @wip
   Scenario: Holder has multiple failed attempts to authenticate the app
@@ -76,7 +76,7 @@ Feature: Secure your Wallet
   # And the User has successfully created a PIN
   # And they land on the Home screen
 
-  @T006-Security @FunctionalTest @ExceptionTest @normal
+  @T006-Security @FunctionalTest @ExceptionTest @normal @qc_wallet_not
   Scenario Outline: New User Sets Up PIN but does not follow conventions
     Given the User has skipped on-boarding
     And the User has accepted the Terms and Conditions

--- a/aries-mobile-tests/features/bc_wallet/terms.feature
+++ b/aries-mobile-tests/features/bc_wallet/terms.feature
@@ -1,5 +1,5 @@
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/hyperledger/aries-mobile-agent-react-native/148
-@TermsAndConditions @bc_wallet @Story_148 @normal
+@TermsAndConditions @bc_wallet @qc_wallet @Story_148 @normal
 Feature: Terms and Conditions
   In order to understand my legal obligations when using the app
   As a new holder

--- a/aries-mobile-tests/features/environment.py
+++ b/aries-mobile-tests/features/environment.py
@@ -48,7 +48,7 @@ def before_feature(context, feature):
     context.verifier = aif.create_verifier_agent_interface(verifier_type, verifier_endpoint)
     context.print_page_source_on_failure = eval(context.config.userdata['print_page_source_on_failure'])
     context.print_qr_code_on_creation = eval(context.config.userdata['print_qr_code_on_creation'])
-    context.save_qr_code_on_creation = eval(context.config.userdata['save_qr_code_on_creation'])
+    context.save_qr_code_on_creation = True if device_cloud_service == 'LocalAndroid' else eval(context.config.userdata['save_qr_code_on_creation'])
 
     # retry failed tests 
     try: 

--- a/aries-mobile-tests/features/qc_wallet/credential_offer.feature
+++ b/aries-mobile-tests/features/qc_wallet/credential_offer.feature
@@ -1,0 +1,25 @@
+@CredentialOffer @qc_wallet @Story_81
+Feature: Offer a Credential
+   In order have confidence and control of my wallet
+   As a holder
+   I want to be able to review, accept, and decline a credential offer
+
+  @T003.x-CredentialOffer @critical @AcceptanceTest
+   Scenario: Holder declines the credential offer recieved
+      Given the User has skipped on-boarding
+      And the User has accepted the Terms and Conditions
+      And a PIN has been set up with "369369"
+      And the Holder has selected to use biometrics to unlock BC Wallet
+      And a connection has been successfully made
+      And the user has a credential offer
+      When they select Decline the credential
+      Then they are brought to the confirm decline page
+      And they select Yes, decline this credential
+      When they select Done
+      Then they are brought Home
+      # Then they are brought to the list of credentials
+      # And a temporary notification will appear that informs the holder of the declined action
+      # And the credential declined is not in the list
+      # Then the holder will be taken to the credential list page
+      # And a temporary notification will appear that informs the holder of the declined action
+      #

--- a/aries-mobile-tests/features/steps/all_steps.py
+++ b/aries-mobile-tests/features/steps/all_steps.py
@@ -1,10 +1,7 @@
-from steps.bc_wallet.bcsc import *
-from steps.bc_wallet.change_language import *
-from steps.bc_wallet.connect import *
-from steps.bc_wallet.credential_offer import *
-from steps.bc_wallet.offline_handling import *
-from steps.bc_wallet.onboarding import *
-from steps.bc_wallet.proof import *
-from steps.bc_wallet.security import *
-from steps.bc_wallet.terms import *
+from steps.qc_wallet.connect import *
+from steps.qc_wallet.credential_offer import *
+from steps.qc_wallet.proof import *
+from steps.qc_wallet.qc_onboarding import *
+from steps.qc_wallet.qc_security import *
+from steps.qc_wallet.qc_terms import *
 

--- a/aries-mobile-tests/features/steps/qc_wallet/connect.py
+++ b/aries-mobile-tests/features/steps/qc_wallet/connect.py
@@ -1,0 +1,1 @@
+from bc_wallet.connect import *

--- a/aries-mobile-tests/features/steps/qc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/qc_wallet/credential_offer.py
@@ -1,0 +1,36 @@
+from bc_wallet.credential_offer import *
+from override_steps import overrides
+from pageobjects.qc_wallet.credential_offer import CredentialOfferPageQC
+
+@overrides('holder is brought to the credential offer screen', 'then')
+def cred_offer_step_impl(context):
+    # Workaround for bug 645
+    context.execute_steps(f'''
+        When the connection takes too long reopen app and select notification
+    ''')
+
+    #assert context.thisConnectingPage.wait_for_connection()
+
+    context.thisCredentialOfferPage = CredentialOfferPageQC(context.driver)
+    assert context.thisCredentialOfferPage.on_this_page()
+
+@when('they select Decline the credential')
+def decline_impl(context):
+    context.isDeclining = True
+    context.thisAreYouSureDeclineCredentialRequest = context.thisCredentialOfferPage.select_decline(scroll=True)
+
+@then('they are brought to the confirm decline page')
+def confirm_decline_page_impl(context):
+    assert context.thisAreYouSureDeclineCredentialRequest.on_this_page() 
+
+@then('they select Yes, decline this credential')
+def decline_cred_impl(context):
+    context.thisCredentialDeclinedPage = context.thisAreYouSureDeclineCredentialRequest.select_confirm()
+
+@overrides('they select Done', 'when')
+def at_home_step_impl(context):
+    if hasattr(context, 'isDeclining') == True: 
+        context.thisHomePage = context.thisCredentialDeclinedPage.select_done()
+    elif hasattr(context, 'thisCredentialsPage') == False:
+        context.thisCredentialAddedPage = CredentialAddedPage(context.driver)
+        context.thisCredentialsPage = context.thisCredentialAddedPage.select_done()

--- a/aries-mobile-tests/features/steps/qc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/qc_wallet/proof.py
@@ -1,0 +1,13 @@
+from bc_wallet.proof import *
+from override_steps import overrides
+
+@overrides('they can view the contents of the proof request', 'then')
+def step_impl(context):
+    assert context.thisProofRequestPage.on_this_page()
+    # who, attributes, values=get_expected_proof_request_detail(
+    #     context)
+    # # The below doesn't have locators in build 127. Calibrate in the future fixed build
+    # actual_who, actual_attributes, actual_values = context.thisProofRequestPage.get_proof_request_details()
+    # assert who in actual_who
+    # assert all(item in attributes for item in actual_attributes)
+    # assert all(item in values for item in actual_values)

--- a/aries-mobile-tests/features/steps/qc_wallet/qc_onboarding.py
+++ b/aries-mobile-tests/features/steps/qc_wallet/qc_onboarding.py
@@ -1,6 +1,13 @@
 from bc_wallet.onboarding import *
 from override_steps import overrides
+from pageobjects.qc_wallet.onboardingtakecontrol import OnboardingTakeControlPageQC
 from pageobjects.qc_wallet.onboardingwelcome import OnboardingWelcomePageQC
+
+
+@overrides('they can select Get started', 'then')
+def get_started_step_impl(context):
+    context.thisOnboardingTakeControlPage = OnboardingTakeControlPageQC(context.driver)
+    context.thisTermsAndConditionsPage = context.thisOnboardingTakeControlPage.select_get_started()
 
 @overrides('the new user has opened the app for the first time', 'given')
 def special_step_impl(context):

--- a/aries-mobile-tests/features/steps/qc_wallet/qc_security.py
+++ b/aries-mobile-tests/features/steps/qc_wallet/qc_security.py
@@ -1,21 +1,71 @@
+from time import sleep
 from bc_wallet.security import *
-from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
 from override_steps import overrides
+from pageobjects.qc_wallet.biometrics import BiometricsPageQC
+
+@overrides('authenticates with thier biometrics', 'when')
+def auth_biometrics_step_impl(context):
+    # Check to see if the Biometrics page is displayed
+    #if ('autoGrantPermissions' in context.driver.capabilities and context.driver.capabilities['autoGrantPermissions'] == False) or (context.driver.capabilities['platformName'] == 'iOS'):
+    context.thisBiometricsPage = BiometricsPageQC(context.driver)
+    assert context.thisBiometricsPage.on_this_page()
+    context.device_service_handler.biometrics_authenticate(True)
+    assert context.thisBiometricsPage.on_this_page() == False
+    context.thisInitializationPage.wait_until_initialized()
+
+@overrides('fails to authenticate with thier biometrics once', 'when')
+def fails_biometrics_step_impl(context):
+    if hasattr(context, 'thisBiometricsPage') == False:
+        context.thisBiometricsPage = BiometricsPageQC(context.driver)
+
+    assert context.thisBiometricsPage.on_this_page()
+    context.device_service_handler.biometrics_authenticate(False)
+    context.thisBiometricsPage.dismiss_biometrics_modal()
+    #assert context.thisBiometricsPage.on_this_page()
+
 
 @then('they select visibility toggle on the first PIN as "{pin}"')
-def step_impl(context, pin):
+def visibility_toggle_first_pin_step_impl(context, pin):
     assert pin == context.thisPINSetupPage.get_pin()
 
 @then('they select visibility toggle on the second PIN as "{pin}"')
-def step_impl(context, pin):
+def visibility_toggle_second_pin_step_impl(context, pin):
     assert pin == context.thisPINSetupPage.get_second_pin()
 
 @overrides('the User selects Create PIN', 'when')
-def special_step_impl(context):
-    next_page = context.thisPINSetupPage.create_pin()
-    if type(next_page) == OnboardingBiometricsPage: 
+@overrides('the User selects Create PIN', 'then')
+def create_pin_step_impl(context):
+    if "TCL_PNG_ACC_002.1" in context.tags or "T005-Security" in context.tags:
+        context.thisPINSetupPage.create_pin_throw_error()
+    else:
+        context.thisOnboardingBiometricsPage = context.thisPINSetupPage.create_pin()
         context.thisOnboardingBiometricsPage.on_this_page()
+    # next_page = context.thisPINSetupPage.create_pin()
+    # if type(next_page) == OnboardingBiometricsPage: 
+    #     context.thisOnboardingBiometricsPage = next_page
+    #     context.thisOnboardingBiometricsPage.on_this_page()
 
 @then('they select ok on PINs error')
-def step_impl(context):
+def select_ok_on_error_step_impl(context):
     context.thisPINSetupPage.select_ok_on_modal()
+
+@overrides('they are informed that the PINs do not match', 'then')
+def step_impl(context):
+    assert context.thisPINSetupPage.get_pin_error() == "PINs do not match"
+
+
+@overrides('they land on the Home screen', 'then')
+@overrides('initialization ends (failing silently)', 'when')
+@overrides('they have access to the app', 'then')
+@overrides('the User has successfully created a PIN', 'then')
+def special_step_impl(context):
+    # The Home page will not show until the initialization page is done. 
+    #assert context.thisInitializationPage.on_this_page()
+    context.thisHomePage = context.thisInitializationPage.wait_until_initialized()
+    context.thisNavBar = NavBar(context.driver)
+    if context.thisHomePage.on_this_page() == False:
+        sleep(3)
+        assert context.thisHomePage.on_this_page()
+    else:
+        assert context.thisHomePage.on_this_page()
+

--- a/aries-mobile-tests/features/steps/qc_wallet/qc_terms.py
+++ b/aries-mobile-tests/features/steps/qc_wallet/qc_terms.py
@@ -1,1 +1,8 @@
 from bc_wallet.terms import *
+from override_steps import overrides
+
+
+@overrides('the users accepts the Terms and Conditions', 'given')
+@overrides('the users accepts the Terms and Conditions', 'when')
+def accept_terms_step_impl(context):
+    context.thisTermsAndConditionsPage.select_accept()

--- a/aries-mobile-tests/pageobjects/qc_wallet/are_you_sure_decline_credential.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/are_you_sure_decline_credential.py
@@ -1,0 +1,19 @@
+from pageobjects.bc_wallet.are_you_sure_decline_proof_request import AreYouSureDeclineProofRequestPage
+
+
+class AreYouSureDeclineCredentialPageQC(AreYouSureDeclineProofRequestPage):
+    """Comfirm the decline of credential page object"""
+
+    # Locators
+    on_this_page_text_locator = "Are you sure you want to decline this credential"
+
+    def __init__(self, driver):
+        super().__init__(driver)
+
+    def select_confirm(self):
+        if self.on_this_page():
+            self.find_by(self.confirm_locator).click()
+            from pageobjects.qc_wallet.credential_declined import CredentialDeclinedPage
+            return CredentialDeclinedPage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/qc_wallet/biometrics.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/biometrics.py
@@ -1,0 +1,25 @@
+import os
+import time
+from appium.webdriver.common.mobileby import MobileBy
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from pageobjects.bc_wallet.biometrics import BiometricsPage
+from pageobjects.bc_wallet.pinsetup import PINSetupPage
+from pageobjects.bc_wallet.initialization import InitializationPage
+
+class BiometricsPageQC(BiometricsPage):
+    """Biometrics enter page QC object"""
+
+    # Locators
+    dismiss_biometrics_modal_locator = (MobileBy.ID, "com.android.systemui:id/button_negative")
+
+    def __init__(self, driver):
+        super().__init__(driver)
+    
+    def dismiss_biometrics_modal(self):
+        if self.driver.capabilities['platformName'] == 'Android':
+            self.find_by(self.dismiss_biometrics_modal_locator).click()
+            return True
+        else:
+            pass
+        

--- a/aries-mobile-tests/pageobjects/qc_wallet/credential_declined.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/credential_declined.py
@@ -1,0 +1,23 @@
+from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import BasePage, WaitCondition
+from pageobjects.bc_wallet.home import HomePage
+
+
+# These classes can inherit from a BasePage to do common setup and functions
+class CredentialDeclinedPage(BasePage):
+    """Credential Declined page object"""
+
+    # Locators
+    on_this_page_text_locator = "Credential Declined"
+    on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/RequestOrOfferDeclined")
+    done_locator = (AppiumBy.ID, "com.ariesbifold:id/Done")
+
+    def on_this_page(self):
+        return super().on_this_page(self.on_this_page_locator)
+
+    def select_done(self):
+        if self.on_this_page():
+            self.find_by(self.done_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            return HomePage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/qc_wallet/credential_offer.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/credential_offer.py
@@ -1,0 +1,42 @@
+from time import sleep
+from pageobjects.basepage import WaitCondition
+from pageobjects.bc_wallet.credential_offer import CredentialOfferPage
+from pageobjects.bc_wallet.credential_on_the_way import CredentialOnTheWayPage
+from pageobjects.qc_wallet.are_you_sure_decline_credential import AreYouSureDeclineCredentialPageQC
+
+class CredentialOfferPageQC(CredentialOfferPage):
+    """Credential Offer Notification QC page object"""
+
+    def __init__(self, driver):
+        super().__init__(driver)
+
+    def select_accept(self, scroll=False):
+        if self.on_this_page():
+            # if the credential has a lot of attributes it could need to scroll
+            if scroll == True:
+                try: 
+                    self.scroll_to_element(self.accept_aid_locator[1])
+                except:
+                    sleep(5)
+                    self.scroll_to_element(self.accept_aid_locator[1])
+                self.find_by(self.accept_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            else:
+                self.find_by(self.accept_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            return CredentialOnTheWayPage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")
+
+    def select_decline(self, scroll=False):
+        if self.on_this_page():
+            # if the credential has a lot of attributes it could need to scroll
+            if scroll == True:
+                try: 
+                    self.find_by(self.decline_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+                except:
+                    self.scroll_to_element(self.accept_aid_locator[1])
+                    self.find_by(self.decline_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            else:
+                self.find_by(self.decline_locator).click()
+            return AreYouSureDeclineCredentialPageQC(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/qc_wallet/onboardingtakecontrol.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/onboardingtakecontrol.py
@@ -1,0 +1,13 @@
+from pageobjects.bc_wallet.onboardingtakecontrol import OnboardingTakeControlPage
+from pageobjects.qc_wallet.termsandconditions import TermsAndConditionsPageQC
+
+# These classes can inherit from a BasePage to do common setup and functions
+class OnboardingTakeControlPageQC(OnboardingTakeControlPage):
+    """Onboarding Take control of your information Screen QC page object"""
+
+    def select_get_started(self):
+        if self.on_this_page():
+            self.find_by(self.get_started_locator).click()
+            return TermsAndConditionsPageQC(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/qc_wallet/pinsetup.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/pinsetup.py
@@ -1,4 +1,5 @@
 from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import WaitCondition
 from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
 from pageobjects.bc_wallet.pinsetup import PINSetupPage
 
@@ -32,13 +33,33 @@ class PINSetupPageQC(PINSetupPage):
         else:
             raise Exception(f"App not on the {type(self)} page")
     
-    def create_pin(self):
+    def create_pin_throw_error(self):
         if self.on_this_page():
-            self.find_by(self.create_pin_button_tid_locator).click()
+            try:
+                self.find_by(self.create_pin_button_tid_locator).click()
+                self.find_by(self.modal_message_ok_locator)
+            except:
+                raise Exception("Unable to locate create pin button and modal error box")
+        else:
+            raise Exception(f"App not on the {type(self)} page")
 
-            if self.find_by(self.modal_message_ok_locator).is_displayed():
-                return PINSetupPageQC(self.driver)
-            # return the wallet initialization page
-            return OnboardingBiometricsPage(self.driver)
+    def create_pin(self):
+        return super().create_pin()
+
+    def select_ok_on_modal(self):
+        # On Android the modal hides all the other PIN setup page elements, so we can't check on this page
+        # if self.on_this_page():
+        self.find_by(self.modal_message_ok_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+        return True
+        # else:
+        #     raise Exception(f"App not on the {type(self)} page
+
+    def does_pin_match(self, header: str = "PINs do not match"):
+        if self.on_this_page():
+            if self.find_by(self.modal_message_title_locator).text == header:
+                return True
+            else:
+                return False
         else:
             raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/qc_wallet/termsandconditions.py
+++ b/aries-mobile-tests/pageobjects/qc_wallet/termsandconditions.py
@@ -1,4 +1,5 @@
 from time import sleep
+from pageobjects.basepage import WaitCondition
 from pageobjects.bc_wallet.pinsetup import PINSetupPage
 from pageobjects.bc_wallet.termsandconditions import TermsAndConditionsPage
 from pageobjects.qc_wallet.pinsetup import PINSetupPageQC
@@ -10,6 +11,20 @@ class TermsAndConditionsPageQC(TermsAndConditionsPage):
 
     def __init__(self, driver):
         super().__init__(driver)
+
+    def select_accept(self):
+        if self.on_this_page():
+            try:
+                self.scroll_to_element(self.back_aid_locator[1])
+            except:
+                # Sometimes it seems that scrolling may try to access the element by accessibility id before it appears
+                # if we get this failure then just sleep and try again. 
+                sleep(5)
+                self.scroll_to_element(self.back_aid_locator[1])
+            self.find_by(self.terms_and_conditions_accept_locator, timeout=30, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            return True
+        else:
+            raise Exception(f"App not on the {type(self)} page")
 
     def select_continue(self):
         if self.on_this_page():


### PR DESCRIPTION
* Added page object model for decling a credential offer
* Fixed tests for pin setup (exceptions and normal)
* Biometry is working on locally (Android)